### PR TITLE
feat(dbt): add base models and seeds for job postings staging

### DIFF
--- a/dbt/job_dbt/macros/normalize_whitespace.sql
+++ b/dbt/job_dbt/macros/normalize_whitespace.sql
@@ -1,0 +1,15 @@
+{% macro normalize_ws(field) %}
+    {#
+        Normalize whitespace in a text field:
+        - Trims leading and trailing whitespace
+        - Collapses multiple consecutive spaces into a single space
+        - Handles NULL values gracefully
+        
+        This is critical for the hash_key calculation to ensure
+        "Acme Corp" and "Acme  Corp" (double space) are treated identically.
+        
+        Usage: {{ normalize_ws('company_name') }}
+    #}
+    REGEXP_REPLACE(TRIM({{ field }}), '\s+', ' ', 'g')
+{% endmacro %}
+

--- a/dbt/job_dbt/models/staging/schema.yml
+++ b/dbt/job_dbt/models/staging/schema.yml
@@ -1,0 +1,128 @@
+version: 2
+
+models:
+  - name: stg_job_postings
+    description: "Staging table for job postings with normalized fields and deduplication"
+    columns:
+      - name: hash_key
+        description: "Primary deduplication key: md5(lower(company)||'|'||lower(title)||'|'||lower(location))"
+        tests:
+          - unique
+          - not_null
+      
+      - name: provider_job_id
+        description: "Job ID from the source provider (if available)"
+      
+      - name: job_link
+        description: "Canonical URL to the job posting"
+      
+      - name: job_title
+        description: "Raw job title from the provider"
+        tests:
+          - not_null
+      
+      - name: company
+        description: "Raw company name from the provider"
+        tests:
+          - not_null
+      
+      - name: company_size
+        description: "Company size bucket (defaults to 'unknown' if not provided)"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-10', '11-50', '51-200', '201-500', '501-1000', '1001-5000', '5001+', 'unknown']
+              config:
+                severity: warn  # Warn instead of error to allow new values during development
+      
+      - name: location
+        description: "Raw location string from the provider"
+        tests:
+          - not_null
+      
+      - name: remote_type
+        description: "Type of remote work arrangement"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['remote', 'hybrid', 'onsite', 'unknown']
+              quote: false
+      
+      - name: contract_type
+        description: "Type of employment contract"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['full_time', 'part_time', 'contract', 'intern', 'temp', 'unknown']
+              quote: false
+      
+      - name: salary_min
+        description: "Minimum salary in original currency"
+      
+      - name: salary_max
+        description: "Maximum salary in original currency"
+      
+      - name: salary_currency
+        description: "ISO 4217 currency code"
+      
+      - name: description
+        description: "Full job description text"
+      
+      - name: skills_raw
+        description: "Array of skills parsed from the provider (if available)"
+      
+      - name: posted_at
+        description: "When the job was originally posted (provider timestamp)"
+      
+      - name: apply_url
+        description: "URL where candidates can apply"
+      
+      - name: source
+        description: "Name of the source API/provider"
+        tests:
+          - not_null
+      
+      - name: first_seen_at
+        description: "Timestamp when this job posting was first ingested into our system"
+        tests:
+          - not_null
+      
+      - name: last_seen_at
+        description: "Timestamp when this job posting was most recently seen"
+        tests:
+          - not_null
+
+seeds:
+  - name: remote_type
+    description: "Reference table for valid remote work types"
+    columns:
+      - name: remote_type
+        description: "Valid remote type value"
+        tests:
+          - unique
+          - not_null
+      - name: description
+        description: "Human-readable description"
+  
+  - name: contract_type
+    description: "Reference table for valid contract types"
+    columns:
+      - name: contract_type
+        description: "Valid contract type value"
+        tests:
+          - unique
+          - not_null
+      - name: description
+        description: "Human-readable description"
+  
+  - name: company_size
+    description: "Reference table for valid company size buckets"
+    columns:
+      - name: company_size
+        description: "Valid company size bucket"
+        tests:
+          - unique
+          - not_null
+      - name: description
+        description: "Human-readable description"
+

--- a/dbt/job_dbt/models/staging/stg_job_postings.sql
+++ b/dbt/job_dbt/models/staging/stg_job_postings.sql
@@ -1,0 +1,141 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='hash_key',
+        on_schema_change='fail'
+    )
+}}
+
+/*
+    Staging model for job postings.
+    
+    This model:
+    - Extracts fields from raw JSONB payloads
+    - Normalizes data types and handles nulls
+    - Calculates hash_key for deduplication (md5 of company|title|location)
+    - Tracks first_seen_at and last_seen_at for each unique posting
+    - Uses incremental strategy to efficiently handle new data
+    
+    The hash_key is our primary deduplication key:
+    hash_key = md5(lower(company) || '|' || lower(title) || '|' || lower(location))
+*/
+
+WITH raw_data AS (
+    SELECT
+        raw_id,
+        source,
+        payload,
+        collected_at
+    FROM {{ source('raw', 'job_postings_raw') }}
+    {% if is_incremental() %}
+    -- Only process new records on incremental runs
+    WHERE collected_at > (SELECT MAX(last_seen_at) FROM {{ this }})
+    {% endif %}
+),
+
+extracted AS (
+    SELECT
+        raw_id,
+        source,
+        collected_at,
+        
+        -- Extract fields from JSONB payload
+        -- Using ->> for text extraction, adjust paths based on actual API structure
+        NULLIF(TRIM(payload->>'provider_job_id'), '')::TEXT AS provider_job_id,
+        NULLIF(TRIM(payload->>'job_link'), '')::TEXT AS job_link,
+        NULLIF(TRIM(payload->>'job_title'), '')::TEXT AS job_title,
+        NULLIF(TRIM(payload->>'company'), '')::TEXT AS company,
+        NULLIF(TRIM(payload->>'location'), '')::TEXT AS location,
+        
+        -- Enums with defaults to 'unknown'
+        COALESCE(NULLIF(TRIM(payload->>'company_size'), ''), 'unknown')::TEXT AS company_size,
+        COALESCE(NULLIF(LOWER(TRIM(payload->>'remote_type')), ''), 'unknown')::TEXT AS remote_type,
+        COALESCE(NULLIF(LOWER(TRIM(payload->>'contract_type')), ''), 'unknown')::TEXT AS contract_type,
+        
+        -- Numeric salary fields
+        NULLIF(payload->>'salary_min', '')::NUMERIC AS salary_min,
+        NULLIF(payload->>'salary_max', '')::NUMERIC AS salary_max,
+        NULLIF(TRIM(payload->>'salary_currency'), '')::TEXT AS salary_currency,
+        
+        -- Text fields
+        NULLIF(TRIM(payload->>'description'), '')::TEXT AS description,
+        NULLIF(TRIM(payload->>'apply_url'), '')::TEXT AS apply_url,
+        
+        -- Array field for skills (if provided by source)
+        CASE 
+            WHEN payload->'skills_raw' IS NOT NULL 
+            THEN ARRAY(
+                SELECT NULLIF(TRIM(value::TEXT, '"'), '')
+                FROM jsonb_array_elements_text(payload->'skills_raw') AS value
+                WHERE NULLIF(TRIM(value::TEXT, '"'), '') IS NOT NULL
+            )
+            ELSE NULL
+        END AS skills_raw,
+        
+        -- Timestamp field
+        NULLIF(payload->>'posted_at', '')::TIMESTAMPTZ AS posted_at
+        
+    FROM raw_data
+),
+
+with_hash AS (
+    SELECT
+        *,
+        -- Calculate hash_key for deduplication
+        -- This is the unique identifier: md5(company|title|location)
+        -- normalize_ws() ensures "Acme Corp" and "Acme  Corp" (double space) are treated identically
+        MD5(
+            LOWER({{ normalize_ws('COALESCE(company, \'\')') }}) || '|' || 
+            LOWER({{ normalize_ws('COALESCE(job_title, \'\')') }}) || '|' || 
+            LOWER({{ normalize_ws('COALESCE(location, \'\')') }})
+        ) AS hash_key
+    FROM extracted
+    WHERE company IS NOT NULL 
+      AND job_title IS NOT NULL 
+      AND location IS NOT NULL
+),
+
+existing_records AS (
+    {% if is_incremental() %}
+    -- Get existing records to preserve first_seen_at timestamps
+    -- This runs once, not once per row (much more efficient!)
+    SELECT 
+        hash_key,
+        first_seen_at
+    FROM {{ this }}
+    {% else %}
+    -- On full refresh, no existing records to preserve
+    SELECT 
+        NULL::TEXT AS hash_key,
+        NULL::TIMESTAMPTZ AS first_seen_at
+    WHERE FALSE
+    {% endif %}
+)
+
+SELECT
+    with_hash.hash_key,
+    with_hash.provider_job_id,
+    with_hash.job_link,
+    with_hash.job_title,
+    with_hash.company,
+    with_hash.company_size,
+    with_hash.location,
+    with_hash.remote_type,
+    with_hash.contract_type,
+    with_hash.salary_min,
+    with_hash.salary_max,
+    with_hash.salary_currency,
+    with_hash.description,
+    with_hash.skills_raw,
+    with_hash.posted_at,
+    with_hash.apply_url,
+    with_hash.source,
+    
+    -- Track when we first and last saw this posting
+    -- If the record exists, preserve first_seen_at; otherwise use current collected_at
+    COALESCE(existing_records.first_seen_at, with_hash.collected_at) AS first_seen_at,
+    with_hash.collected_at AS last_seen_at
+    
+FROM with_hash
+LEFT JOIN existing_records ON with_hash.hash_key = existing_records.hash_key
+

--- a/dbt/job_dbt/seeds/company_size.csv
+++ b/dbt/job_dbt/seeds/company_size.csv
@@ -1,0 +1,10 @@
+company_size,description
+1-10,1-10 employees
+11-50,11-50 employees
+51-200,51-200 employees
+201-500,201-500 employees
+501-1000,501-1000 employees
+1001-5000,1001-5000 employees
+5001+,5001+ employees
+unknown,Company size not specified
+

--- a/dbt/job_dbt/seeds/contract_type.csv
+++ b/dbt/job_dbt/seeds/contract_type.csv
@@ -1,0 +1,8 @@
+contract_type,description
+full_time,Full-time employment
+part_time,Part-time employment
+contract,Contract or freelance
+intern,Internship
+temp,Temporary employment
+unknown,Contract type not specified
+

--- a/dbt/job_dbt/seeds/remote_type.csv
+++ b/dbt/job_dbt/seeds/remote_type.csv
@@ -1,0 +1,6 @@
+remote_type,description
+remote,Fully remote position
+hybrid,Hybrid (mix of remote and onsite)
+onsite,Fully onsite position
+unknown,Remote type not specified
+


### PR DESCRIPTION
- Add stg_job_postings model with incremental materialization
  - Extract fields from raw JSONB payloads
  - Calculate hash_key for deduplication (md5 of company|title|location)
  - Track first_seen_at and last_seen_at timestamps
  - Implement efficient LEFT JOIN pattern for incremental runs

- Create normalize_ws() macro for whitespace normalization
  - Ensures consistent hash_key generation across data sources
  - Handles multiple spaces, leading/trailing whitespace

- Add enum seed files:
  - remote_type: remote, hybrid, onsite, unknown
  - contract_type: full_time, part_time, contract, intern, temp, unknown
  - company_size: 1-10, 11-50, 51-200, 201-500, 501-1000, 1001-5000, 5001+, unknown

- Define comprehensive tests in schema.yml:
  - unique and not_null tests on hash_key
  - accepted_values tests for all enum fields
  - not_null tests on required fields

Resolves TODO: Write base models & seeds (Phase 0) Acceptance Criteria: âœ… All met
- raw.job_postings_raw source defined
- staging.job_postings_stg model compiles
- Enum seeds load successfully
- Generic tests defined